### PR TITLE
fix(tsconfig): use esModuleInterop flag

### DIFF
--- a/packages/url/tsconfig.json
+++ b/packages/url/tsconfig.json
@@ -3,5 +3,7 @@
   "include": ["./src"],
   "compilerOptions": {
     "outDir": "./dist"
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop" true, 
   }
 }


### PR DESCRIPTION
The dependency of this package, @ethersproject/experimental  imports EventEmitter, 

```typescript
// source: see `@ethersproject/experimental/ib/eip1193-bridge.d.ts:2:8`
import EventEmitter from "events";
```

The Module '"`events`"' can only be default-imported using the `esModuleInterop` flag
Enabling `esModuleInterop` will also enable `allowSyntheticDefaultImports`.

This explicitly defines this compiler flag for this package. I did not know if you wanted to enable it for the whole monorepo.

Cheers